### PR TITLE
Suggested syntax and cleanup

### DIFF
--- a/ddclient/files/ddclient.conf
+++ b/ddclient/files/ddclient.conf
@@ -1,6 +1,5 @@
-{%- set ddclient = pillar.get('ddclient', {}) %}
-{%- set globals = ddclient.get('globals', {}) %}
-{%- set hosts = ddclient.get('hosts', {}) %}
+{%- set globals = salt['pillar.get']('ddclient:globals', {}) %}
+{%- set hosts = salt['pillar.get']('ddclient:hosts', {}) %}
 #
 # This file is managed by salt.
 # Run `ddclient -help` to see examples of how to configure ddclient

--- a/ddclient/init.sls
+++ b/ddclient/init.sls
@@ -3,8 +3,7 @@
 ddclient:
   pkg.installed:
     - name: {{ ddclient.package }}
-  service:
-    - running
+  service.running:
     - enable: True
     - watch:
       - file: ddclient_config

--- a/ddclient/map.jinja
+++ b/ddclient/map.jinja
@@ -1,11 +1,5 @@
 {% set ddclient = salt['grains.filter_by']({
-    'Debian': {
-        'package': 'ddclient',
-        'service': 'ddclient',
-        'config': '/etc/ddclient.conf',
-        'config_src': 'salt://ddclient/files/ddclient.conf',
-    },
-    'RedHat': {
+    'default': {
         'package': 'ddclient',
         'service': 'ddclient',
         'config': '/etc/ddclient.conf',


### PR DESCRIPTION
I modified the service to follow the suggested syntax. Also in the map file there's 2 identical entries that can be substituted with a `'default'` key. Finally in the `ddclient.conf` template the variables can be retrieved using the `salt['pillar.get']` function and the `:` delimiter.
